### PR TITLE
Fix Building Properties

### DIFF
--- a/1.4/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings.xml
@@ -40,16 +40,10 @@
 		<inspectorTabs>
 			<li>ITab_Bills</li>
 		</inspectorTabs>
-		<building>
-			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
-			<sowTag>SupportPlantsOnly</sowTag>
-			<canPlaceOverImpassablePlant>false</canPlaceOverImpassablePlant>
-			<ai_chillDestination>false</ai_chillDestination>
-			<artificialForMeditationPurposes>false</artificialForMeditationPurposes>
-			<buildingTags>
-				<li>Production</li>
-			</buildingTags>
-		</building>
+	    	<building>
+	      		<isMealSource>true</isMealSource>
+	      		<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
+	    	</building>
 		<size>(3,1)</size>
 		<designationCategory>Production</designationCategory>
 		<passability>PassThroughOnly</passability>


### PR DESCRIPTION
Similar fix as proposed in Vanilla Cooking Expanded Core. Addresses some minor bugs and inconsistencies with Vanilla behaviour, and makes it easier for other mods to identify this as a potential food source.